### PR TITLE
Use libc++

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,9 +1,35 @@
 #!/usr/bin/env bash
 
-# See http://www.unidata.ucar.edu/support/help/MailArchives/netcdf/msg11939.html
-if [ "$(uname)" == "Darwin" ]; then
+if [ "$(uname)" == "Darwin" ]
+then
+    # for Mac OSX
+    export CC=clang
+    export CXX=clang++
+    export MACOSX_VERSION_MIN="10.7"
+    export MACOSX_DEPLOYMENT_TARGET="${MACOSX_VERSION_MIN}"
+    export CXXFLAGS="${CXXFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
+    export CXXFLAGS="${CXXFLAGS} -stdlib=libc++ -std=c++11"
+    export LDFLAGS="${LDFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
+    export LDFLAGS="${LDFLAGS} -stdlib=libc++ -lc++"
+    export LINKFLAGS="${LDFLAGS}"
+    # See http://www.unidata.ucar.edu/support/help/MailArchives/netcdf/msg11939.html
     export DYLD_LIBRARY_PATH=${PREFIX}/lib
+elif [ "$(uname)" == "Linux" ]
+then
+    # for Linux
+    export CC=gcc
+    export CXX=g++
+    export CXXFLAGS="${CXXFLAGS} -DBOOST_MATH_DISABLE_FLOAT128"
+    export LDFLAGS="${LDFLAGS}"
+    export LINKFLAGS="${LDFLAGS}"
+else
+    echo "This system is unsupported by the toolchain."
+    exit 1
 fi
+
+export CFLAGS="${CFLAGS} -m${ARCH}"
+export CXXFLAGS="${CXXFLAGS} -m${ARCH}"
+
 
 CPPFLAGS=-I$PREFIX/include LDFLAGS=-L$PREFIX/lib ./configure --prefix=$PREFIX
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   git_tag: v{{ version }}
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
I was trying to link to netcdf-cxx4 https://github.com/conda-forge/staged-recipes/pull/591, but it was effortless on MacOSX. 

Unfortunately the actual netcdf-cxx4 is comiled and linked against libstdc++ (with gcc, not clang), this leads to those `Undefined symbols for architecture x86_64` errors while linking.

As a last resort I added the netcdf-cxx4 recipe there and added these changes there. This made the libradolan compile correclty, also the library is installed correctly. Unfortunately I can't test one compiled binary there, because it uses the netcdf-cxx4 conda-forge package and not the recipe-build for the `run:`-part. 

If this is consensus, that we should use `libc++` explicitely on MacOSX instead of whatever is the default, then we can merge this, when we have green lights.

cc @ocefpaf, @jakirkham 
