### PR TITLE
Create symlinks

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -32,3 +32,8 @@ cmake -D CMAKE_INSTALL_PREFIX=$PREFIX \
 make
 ctest
 make install
+
+# Workaround cmake's libnetcdf-cxx4 and configure's libnetcdf_c++4.
+for fname in $PREFIX/lib/libnetcdf-cxx4.*; do
+  ln -s $fname $PREFIX/lib/libnetcdf_c++4.${fname#*.}
+done

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 25da1c97d7a01bc4cee34121c32909872edd38404589c0427fefa1301743f18f
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win]
 
 requirements:
@@ -26,6 +26,7 @@ test:
   commands:
     #- ncxx4-config --all  # FIXME: no ncxx4-config for cmake yet.
     - test -f ${PREFIX}/lib/libnetcdf-cxx4.a  # [unix]
+    - test -f ${PREFIX}/lib/libnetcdf_c++4.a  # [unix]
     - conda inspect linkages -n _test netcdf-cxx4  # [linux]
 
 about:

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -8,11 +8,17 @@ platform = sys.platform
 if platform.startswith('linux'):
     path = os.path.join(sys.prefix, 'lib', 'libnetcdf-cxx4.so')
     lib = ctypes.CDLL(path)
+    path = os.path.join(sys.prefix, 'lib', 'libnetcdf_c++4.so')
+    lib = ctypes.CDLL(path)
 elif platform == 'darwin':
     path = os.path.join(sys.prefix, 'lib', 'libnetcdf-cxx4.dylib')
     lib = ctypes.CDLL(path)
+    path = os.path.join(sys.prefix, 'lib', 'libnetcdf_c++4.dylib')
+    lib = ctypes.CDLL(path)
 elif platform == 'win32':
     path = os.path.join(sys.prefix, 'Library', 'bin', 'libnetcdf-cxx4.dll')
+    lib = ctypes.CDLL(path)
+    path = os.path.join(sys.prefix, 'Library', 'bin', 'libnetcdf_c++4.dll')
     lib = ctypes.CDLL(path)
 else:
     raise ValueError('Unrecognized platform: {}'.format(platform))


### PR DESCRIPTION
@WardF there is a name difference when we build `netcdf-cxx4` with `configure` or `cmake`. For now we are creating a workaround and adding both names via a symlink. However, it would be nice to get this fixed upstream and settle on a single name (if that makes sense for your goals too).

Ping @kmuehlbauer 