### PR TITLE
Fix stdlib libc++ linkage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
 
       conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
+      conda install --yes conda-build jinja2 anaconda-client
       conda config --add channels conda-forge
       
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+if [ $(uname) == Darwin ]; then
+  export CXX="${CXX} -stdlib=libc++"
+fi
+
 # Build shared library using cmake
 # works for both linux and osx, but missing ncxx4-config
 # see https://github.com/Unidata/netcdf-cxx4/issues/36

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,13 +10,14 @@ source:
   sha256: 25da1c97d7a01bc4cee34121c32909872edd38404589c0427fefa1301743f18f
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win]
 
 requirements:
   build:
     - cmake
     - libnetcdf 4.4.*
+    - toolchain
   run:
     - libnetcdf 4.4.*
 


### PR DESCRIPTION
Ping @kmuehlbauer. I guess we can re-add the `toolchain` with the latest `conda-build`. Let's see how this goes and then we can do the same in `libradolan`.