### PR TITLE
Add run_export

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "4.3.1" %}
-{% set build = 13 %}
+{% set build = 14 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'nompi' %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,28 @@
 {% set build = build + 100 %}
 {% endif %}
 
+# add build string so packages can depend on
+# mpi or nompi variants explicitly:
+# `netcdf-cxx4 * mpi_mpich_*` for mpich
+# `netcdf-cxx4 * mpi_*` for any mpi
+# `netcdf-cxx4 * nompi_*` for no mpi
+
+{% if mpi != 'nompi' %}
+{% set mpi_prefix = "mpi_" + mpi %}
+{% else %}
+{% set mpi_prefix = "nompi" %}
+{% endif %}
+
+# mpi builds require the right mpi
+# non-mpi builds *do not* appear to require non-mpi builds
+# at least not always
+
+{% if mpi != 'nompi' %}
+{% set build_pin = mpi_prefix + '_*' %}
+{% else %}
+{% set build_pin = '' %}
+{% endif %}
+
 package:
   name: netcdf-cxx4
   version: {{ version }}
@@ -31,19 +53,9 @@ source:
 
 build:
   number: {{ build }}
-
-  # add build string so packages can depend on
-  # mpi or nompi variants explicitly:
-  # `netcdf-cxx4 * mpi_mpich_*` for mpich
-  # `netcdf-cxx4 * mpi_*` for any mpi
-  # `netcdf-cxx4 * nompi_*` for no mpi
-
-  {% if mpi != 'nompi' %}
-  {% set mpi_prefix = "mpi_" + mpi %}
-  {% else %}
-  {% set mpi_prefix = "nompi" %}
-  {% endif %}
   string: "{{ mpi_prefix }}_h{{ PKG_HASH }}_{{ build }}"
+  run_exports:
+    - {{ pin_subpackage('netcdf-cxx4', max_pin='x.x.x') }} {{ build_pin }}
 
 requirements:
   build:


### PR DESCRIPTION
The package does not have run_export, while as it builds a library it may be benefitial to have.
I've taken inspiration from [hdf5 package](https://github.com/conda-forge/hdf5-feedstock/blob/main/recipe/meta.yaml)

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
